### PR TITLE
Se añade función onAfterShow para evitar desbloquear el campo Estado …

### DIFF
--- a/custom/views/call-edit-view/call-edit.js
+++ b/custom/views/call-edit-view/call-edit.js
@@ -218,6 +218,14 @@ const CallEditView = customization.extend(EditView, {
     },
 
     /*
+    * Función para evitar que el campo "Estado" se desbloquee al escribir en "Descripción" o 
+    * en "Relacionado con"
+    */
+    onAfterShow(options){
+      this.disableStatus();
+    },
+
+    /*
     * Se bloquea campo "Estado" al tener registro de Reunión como Realizada o No Realizada
     */
 

--- a/custom/views/meetings-edit-view/meeting-edit.js
+++ b/custom/views/meetings-edit-view/meeting-edit.js
@@ -25,6 +25,14 @@ const MeetingEditView = customization.extend(EditView, {
     },
 
     /*
+    * Función para evitar que el campo "Estado" se desbloquee al escribir en "Descripción" o 
+    * en "Relacionado con"
+    */
+    onAfterShow(options){
+      this.disableStatus();
+    },
+
+    /*
     * Se establecen como solo lectura el "Objetivo" y "Resultado" una vez que se ha sincronizado
     * completamente la información del registro y el Estado sea "Realizada" o "No Realizada"
     */


### PR DESCRIPTION
…al seleccionar 'Descricpión' o 'Relacionado con'